### PR TITLE
PADV-2663 - Add PEP-440 support for function _sourcelib_str_to_tuple

### DIFF
--- a/edx_event_bus_redis/internal/utils.py
+++ b/edx_event_bus_redis/internal/utils.py
@@ -30,7 +30,7 @@ def _sourcelib_tuple_to_str(sourcelib: Tuple):
 
 
 def _sourcelib_str_to_tuple(sourcelib_as_str: str):
-    return tuple(map(int, sourcelib_as_str.split(".")))
+    return tuple(sourcelib_as_str.split("."))
 
 
 def encode(value: str) -> bytes:


### PR DESCRIPTION
## Tickets

- [https://agile-jira.pearson.com/browse/PADV-2663](https://pearson.atlassian.net/browse/PADV-2663)

## Description

The Redis Event Bus adapter was failing when reading our custom Open edX Events version string.
Upstream uses purely numeric versions (e.g. 10.5.0), but we publish post-releases following PEP 440 (e.g. 9.10.post1).

The _sourcelib_str_to_tuple helper tried to convert every component to int, which breaks on the "post" segment.

Current Behavior:

<img width="1839" height="551" alt="image" src="https://github.com/user-attachments/assets/db625bda-6427-424d-92ff-79dad7bda209" />


Expected Behavior:
<img width="1835" height="366" alt="image" src="https://github.com/user-attachments/assets/bffa4088-a479-4e43-8e4f-7e511b7a3b35" />

## Changes Made

- Modify _sourcelib_str_to_tuple

## How to test

- Ran the Event Bus with both standard (10.5.0) and post-release (9.10.0.post2) versions.
- Confirmed that messages are published/consumed without errors.